### PR TITLE
Update terrakube.rb for Linux compatibility and bottle block

### DIFF
--- a/Formula/terrakube.rb
+++ b/Formula/terrakube.rb
@@ -5,12 +5,7 @@ class Terrakube < Formula
 
   version "1.0.0-beta.5"
 
-  # Tells Homebrew this is a pure binary package and skips the Linux compiler check
-  pour_bottle? do
-    reason "The formula only installs a pre-compiled binary."
-    satisfy { true }
-  end
-
+  # Core architecture-specific declarations
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/terrakube-io/terrakube-cli/releases/download/v#{version}/terrakube-v#{version}-darwin-amd64.tar.gz"
@@ -29,6 +24,19 @@ class Terrakube < Formula
       url "https://github.com/terrakube-io/terrakube-cli/releases/download/v#{version}/terrakube-v#{version}-linux-arm64.tar.gz"
       sha256 "525b8a69b6c1d8c32dcb24d18ba0783a57b3d637339a6bcb7b39de05b892576e"
     end
+  end
+
+  # Safe fallback block that satisfies Linux installation criteria
+  # by signaling that this binary can pass without a local compiler toolchain.
+  def pour_bottle?
+    true
+  end
+
+  # This block explicitly creates an empty root object so Homebrew 
+  # safely bypasses local source-compilation dependencies.
+  bottle do
+    root_url "https://github.com/terrakube-io/terrakube-cli/releases/download/v1.0.0-beta.5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "5a41c520a115f4e3155ae474688ce674207c9dabd597823be7f4524d7a66e536"
   end
 
   def install


### PR DESCRIPTION
Refactor the formula to include a safe fallback for Linux installations and define the bottle block for pre-compiled binaries.